### PR TITLE
Update version to "0.1.17" in `__init__.py` and `pyproject.toml`

### DIFF
--- a/guvicorn_logger/__init__.py
+++ b/guvicorn_logger/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.17b0"
+__version__ = "0.1.17"
 
 from .core import AccessFormatter as AccessFormatter
 from .core import DefaultFormatter as DefaultFormatter

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "guvicorn_logger"
-version = "0.1.17b0"
+version = "0.1.17"
 description = "Colored, normalizes and joins logs between Uvicorn and Gunicorn."
 authors = ["carlos.rian <crian.rian@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
Expose the format class to edit.

https://pypi.org/project/guvicorn_logger/0.1.17/

*Install new version*
```sh
pip install guvicorn_logger==0.1.17
```


*Test*
```py
from datetime import datetime
from pytz import timezone
from guvicorn_logger.core import AccessFormatter, DefaultFormatter

def timetz(*args):
    tz = timezone("Asia/Shanghai")  # UTC, Asia/Shanghai, Europe/Berlin
    return datetime.now(tz).timetuple()

AccessFormatter.converter = timetz
DefaultFormatter.converter = timetz

logger = Logger().configure()

logger.info("Information")
logger.error("Error")
logger.warning("Warning")
logger.critical("Critical")
```

